### PR TITLE
[Warden] Correct column type for checkID

### DIFF
--- a/Updates/Rel21/20150420_03_warden_db_log.sql
+++ b/Updates/Rel21/20150420_03_warden_db_log.sql
@@ -1,0 +1,69 @@
+-- --------------------------------------------------------------------------------
+-- This is an attempt to create a full transactional update
+-- --------------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS `update_mangos`; 
+
+DELIMITER $$
+
+CREATE DEFINER=`root`@`localhost` PROCEDURE `update_mangos`()
+BEGIN
+    DECLARE bRollback BOOL  DEFAULT FALSE ;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET `bRollback` = TRUE;
+
+  SET @cOldRev = 'required_20150412_auth_realmlist'; 
+
+  -- Set the new revision string
+  SET @cNewRev = 'required_20150420_warden_db_log';
+
+  -- Set thisRevision to the column name of db_version in the currently selected database
+  SET @cThisRev := ((SELECT column_name FROM information_schema.`COLUMNS` WHERE table_name='realmd_db_version' AND table_schema=(SELECT DATABASE() AS thisDB FROM DUAL) AND column_name LIKE 'required%'));
+
+  -- Set friendly Version Text
+  SET @cThisVersion = 'RealmDB Rev 20150420_01';
+
+ 
+  -- Only Proceed if the old values match
+  IF @cThisRev = @cOldRev THEN
+    -- Make this all a single transaction
+    START TRANSACTION;
+
+    -- Apply the Version Change from Old Version to New Version
+    SET @query = CONCAT('ALTER TABLE realmd_db_version CHANGE COLUMN ',@cOldRev, ' ' ,@cNewRev,' bit;');
+    PREPARE stmt1 FROM @query;
+    EXECUTE stmt1;
+    DEALLOCATE PREPARE stmt1;
+    -- The Above block is required for making table changes
+
+    -- Change column for warden checkID to fit uint16 rather than uint8
+    SET @query = 'ALTER TABLE warden_log MODIFY COLUMN `check` SMALLINT(5) UNSIGNED NOT NULL COMMENT "Failed Warden check ID";';
+    PREPARE stmt2 FROM @query;
+    EXECUTE stmt2;
+    DEALLOCATE PREPARE stmt2;
+    -- The Above block is required for making table changes
+
+    -- -- -- -- Normal Update / Insert / Delete statements will go here  -- -- -- -- --
+
+    -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+    
+    -- If we get here ok, commit the changes
+    IF bRollback = TRUE THEN
+      ROLLBACK;
+      SELECT '* UPDATE FAILED *' AS 'Status',@cThisRev AS 'DB is on Version';
+    ELSE
+      COMMIT;
+      SELECT '* UPDATE COMPLETE *' AS 'Status',@cNewRev AS 'DB is now on Version';
+    END IF;
+  ELSE
+    SELECT '* UPDATE SKIPPED *' AS 'Status',@cOldRev AS 'Required Version',@cThisRev AS 'Found Version';
+  END IF;
+
+END $$
+
+DELIMITER ;
+
+-- Execute the procedure
+CALL update_mangos();
+
+-- Drop the procedure
+DROP PROCEDURE IF EXISTS `update_mangos`;
+


### PR DESCRIPTION
Old version wrote (warden checkID mod 256) due to incorrect column type TINYINT.
See also the core modification.
